### PR TITLE
Downgrade boto3 library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ dnspython==2.1.0
 mongoengine==0.27.0
 pymongo==3.13.0
 pymongocrypt==1.9.2
-boto3==1.34.130
+boto3==1.34.106

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'dnspython>=2.0.0,<2.2.0',
         'pymongo>=3.11.0,<4.0.0',
         'pymongocrypt>=1.9.2,<2.0.0',
-        'boto3>=1.34.109',
+        'boto3>=1.34.106',
     ],
     classifiers=[
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'dnspython>=2.0.0,<2.2.0',
         'pymongo>=3.11.0,<4.0.0',
         'pymongocrypt>=1.9.2,<2.0.0',
-        'boto3>=1.34.130',
+        'boto3>=1.34.109',
     ],
     classifiers=[
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
 aiobotocore 2.13.0 depends on botocore<1.34.107 and >=1.34.70
y al actualizar en fast-agave manda error de conflicto